### PR TITLE
Update create-a-new-reactjs-app.md

### DIFF
--- a/_chapters/create-a-new-reactjs-app.md
+++ b/_chapters/create-a-new-reactjs-app.md
@@ -35,12 +35,6 @@ This should take a second to run.
 
 We also want to load the environment variables from our backend. To do this, we’ll be using the [`sst bind`](https://docs.sst.dev/packages/sst#sst-bind) CLI. It'll find the environment variables from our SST app and load it while starting the React development environment. We'll set these environment variables below.
 
-{%change%} Run the following **in the `packages/frontend/` directory**.
-
-```bash
-$ pnpm add --save-dev sst
-```
-
 To use the CLI, we'll add it to our `package.json` scripts.
 
 {%change%} Replace the `dev` script in your `packages/frontend/package.json`.


### PR DESCRIPTION
Following the – otherwise incredibly amazing guide – there seems to be an issue on the following page: https://sst.dev/chapters/create-a-new-reactjs-app.html

When installing `sst` to `packages/frontend`, it fails with the following error when running `pnpm run dev`:

```
Error: No app is set

Trace: Error: No app is set
    at use (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22/node_modules/sst/constructs/FunctionalStack.js:44:15)
    at EmptyStack.ApiStack (file:///Users/jonasthiesen/code/sst-example/notes/.sst.config.1694033489155.mjs:35:21)
    at stack (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/constructs/FunctionalStack.js:20:35)
    at App.stack (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/constructs/App.js:490:16)
    at Object.stacks [as fn] (file:///Users/jonasthiesen/code/sst-example/notes/.sst.config.1694033489155.mjs:131:29)
    at Module.synth (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/stacks/synth.js:63:20)
    at async buildApp (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/cli/commands/bind.js:86:13)
    at async Object.handler (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/cli/commands/bind.js:51:9)
    at process.<anonymous> (file:///Users/jonasthiesen/code/sst-example/notes/node_modules/.pnpm/sst@2.24.22_@types+react@18.2.21/node_modules/sst/cli/sst.js:62:21)
    at process.emit (node:events:525:35)
    at process.emit (node:domain:489:12)
    at process._fatalException (node:internal/process/execution:149:25)
    at processPromiseRejections (node:internal/process/promises:288:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:96:32)
```

To me this sounds like it's getting a new "instance" of sst is created that doesn't have the app setup, which then let me to investigate the examples you have, e.g. this one: https://github.com/sst/sst/blob/0101c9f86c4c8c7ac7c05939d51b05c9050e12b4/examples/react-app/packages/frontend/package.json

On that one `sst` is not installed into `packages/frontend` itself.

I removed `sst` from `packages/frontend` and it seems to work perfectly now.