### PR TITLE
change npx sst dev to pnpm

### DIFF
--- a/_chapters/create-a-dynamodb-table-in-sst.md
+++ b/_chapters/create-a-dynamodb-table-in-sst.md
@@ -113,7 +113,7 @@ export default {
 
 If you switch over to your terminal, you'll notice that you are being prompted to redeploy your changes. Go ahead and hit _ENTER_.
 
-Note that, you'll need to have `sst dev` running for this to happen. If you had previously stopped it, then running `npx sst dev` will deploy your changes again.
+Note that, you'll need to have `sst dev` running for this to happen. If you had previously stopped it, then running `pnpm sst dev` will deploy your changes again.
 
 You should see something like this at the end of the deploy process.
 

--- a/_chapters/create-an-s3-bucket-in-sst.md
+++ b/_chapters/create-an-s3-bucket-in-sst.md
@@ -42,14 +42,14 @@ return {
 
 ```typescript
 return {
-  bucket,
-  table,
+    bucket,
+    table,
 };
 ```
 
 This will allow us to reference the S3 bucket in other stacks.
 
-Note, learn more about sharing resources between stacks [here](https://docs.sst.dev/constructs/Stack#sharing-resources-between-stacks){:target="\_blank"}.
+Note, learn more about sharing resources between stacks [here](https://docs.sst.dev/constructs/Stack#sharing-resources-between-stacks){:target="_blank"}.
 
 ### Deploy the App
 

--- a/_chapters/create-an-s3-bucket-in-sst.md
+++ b/_chapters/create-an-s3-bucket-in-sst.md
@@ -42,20 +42,20 @@ return {
 
 ```typescript
 return {
-    bucket,
-    table,
+  bucket,
+  table,
 };
 ```
 
 This will allow us to reference the S3 bucket in other stacks.
 
-Note, learn more about sharing resources between stacks [here](https://docs.sst.dev/constructs/Stack#sharing-resources-between-stacks){:target="_blank"}.
+Note, learn more about sharing resources between stacks [here](https://docs.sst.dev/constructs/Stack#sharing-resources-between-stacks){:target="\_blank"}.
 
 ### Deploy the App
 
 If you switch over to your terminal, you will notice that your changes are being deployed.
 
-Note that, you will need to have `sst dev` running for this to happen. If you had previously stopped it, then running `npx sst dev` will deploy your changes again.
+Note that, you will need to have `sst dev` running for this to happen. If you had previously stopped it, then running `pnpm sst dev` will deploy your changes again.
 
 You should see that the storage stack has been updated.
 


### PR DESCRIPTION
change npx sst dev to pnpm sst dev to stay consistent with the previous section using pnpm to remove the API stack.