### PR TITLE
change npx sst dev to pnpm sst dev

### DIFF
--- a/_chapters/create-a-dynamodb-table-in-sst.md
+++ b/_chapters/create-a-dynamodb-table-in-sst.md
@@ -113,7 +113,7 @@ export default {
 
 If you switch over to your terminal, you'll notice that you are being prompted to redeploy your changes. Go ahead and hit _ENTER_.
 
-Note that, you'll need to have `sst dev` running for this to happen. If you had previously stopped it, then running `npx sst dev` will deploy your changes again.
+Note that, you'll need to have `sst dev` running for this to happen. If you had previously stopped it, then running `pnpm sst dev` will deploy your changes again.
 
 You should see something like this at the end of the deploy process.
 

--- a/_chapters/create-an-s3-bucket-in-sst.md
+++ b/_chapters/create-an-s3-bucket-in-sst.md
@@ -55,7 +55,7 @@ Note, learn more about sharing resources between stacks [here](https://docs.sst.
 
 If you switch over to your terminal, you will notice that your changes are being deployed.
 
-Note that, you will need to have `sst dev` running for this to happen. If you had previously stopped it, then running `npx sst dev` will deploy your changes again.
+Note that, you will need to have `sst dev` running for this to happen. If you had previously stopped it, then running `pnpm sst dev` will deploy your changes again.
 
 You should see that the storage stack has been updated.
 


### PR DESCRIPTION
Change npx to pnpm to be consistent with the documentation earlier on the same page. In addition, every section named Deploy Our Changes in the following chapter (BUILDING A SERVERLESS API) references this command using pnpm and not npx.