### PR TITLE
Update secure-our-serverless-apis.md

### DIFF
--- a/_chapters/secure-our-serverless-apis.md
+++ b/_chapters/secure-our-serverless-apis.md
@@ -119,7 +119,7 @@ While this might look intimidating, just keep in mind that behind the scenes all
 If you are on Windows, you can use the command below. The spaces between each option are very important.
 
 ```bash
-$ pnpm dlx aws-api-gateway-cli-test --username admin@example.com --password Passw0rd! --user-pool-id <USER_POOL_ID> --app-client-id <USER_POOL_CLIENT_ID> --cognito-region <COGNITO_REGION> --identity-pool-id <IDENTITY_POOL_ID> --invoke-url <API_ENDPOINT> --api-gateway-region <API_REGION> --path-template /notes --method POST --body '{""content\":\"hello world\",\"attachment\":\"hello.jpg\"}'
+$ pnpm dlx aws-api-gateway-cli-test --username admin@example.com --password Passw0rd! --user-pool-id <USER_POOL_ID> --app-client-id <USER_POOL_CLIENT_ID> --cognito-region <COGNITO_REGION> --identity-pool-id <IDENTITY_POOL_ID> --invoke-url <API_ENDPOINT> --api-gateway-region <API_REGION> --path-template /notes --method POST --body "{\"content\":\"hello world\",\"attachment\":\"hello.jpg\"}"
 ```
 {%endinfo%}
 


### PR DESCRIPTION
According to this AWS Document: https://docs.aws.amazon.com/cli/latest/userguide/cli-usage-parameters-quoting-strings.html on the Windows OS, quoted strings are enclosed in double quotes (") and intermediate quotes are escaped (\).
This worked for me.